### PR TITLE
Update monaco-element.js

### DIFF
--- a/monaco-element.js
+++ b/monaco-element.js
@@ -68,7 +68,8 @@ class MonacoElement extends PolymerElement {
       readOnly: {
         type: Boolean,
         value: false,
-        reflectToAttribute: true
+        reflectToAttribute: true,
+        observer: "monacoReadOnlyChanged"
       },
       automaticLayout: {
         type: Boolean,


### PR DESCRIPTION
Add an observer to readOnly property to make it possible to change on the fly the read-only status of the editor